### PR TITLE
fix: add support for Polymer 2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-timeago",
-  "description": "Polymer 1.0 element that shows a date/time as 'some time ago' using https://date-fns.org",
+  "description": "Polymer 2.0 element that shows a date/time as 'some time ago' using https://date-fns.org",
   "main": "iron-timeago.html",
   "keywords": [
     "web-component",
@@ -22,13 +22,27 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.4.0",
+    "polymer": "Polymer/polymer#1 - 2",
     "date-fns": "date-fns#^1.27.1"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-    "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
+    "web-component-tester": "^6.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.9",
+        "date-fns": "date-fns#^1.27.1"
+      },
+      "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+        "web-component-tester": "Polymer/web-component-tester#^4.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+      }
+    }
   }
 }

--- a/iron-timeago.html
+++ b/iron-timeago.html
@@ -11,9 +11,6 @@ Polymer 1.0 element that shows a date/time as 'some time ago' using https://date
 
 <dom-module id="iron-timeago">
   <template>
-    <style>
-    </style>
-
     <time datetime="[[datetime]]">[[timeago]]</time>
   </template>
 


### PR DESCRIPTION
- `resolutions` are no longer needed for Polymer 2.0
- Polymer 1.0 is still supported